### PR TITLE
Optimization options

### DIFF
--- a/docs/content/getting-started/faqs.md
+++ b/docs/content/getting-started/faqs.md
@@ -23,6 +23,16 @@ In the following section, we address common questions and potential issues you m
   - For maximum speed, consider using our custom backends.
   - Trade accuracy for speed with `model.forecast(..., full_rollout=True)` (predicts the whole horizon in one forward pass) or `dynamic_padding=True` (pads short contexts to the next patch instead of the full training context length). See the [forecasting workflow](../how-to/forecasting/workflow.md).
 
+  A quick estimation of the speed–accuracy trade-off (Setting: batch size 5, context length 128, prediction length 64, `torch` backend, average of 50 calls; MASE and CRPS are lower-is-better):
+
+  | Option | CPU | GPU | MASE (Gifteval) | CRPS (Gifteval) |
+  | --- | --- | --- | --- | --- |
+  | Default (both off) | 416 ms | 233 ms | 0.724 | 0.499 |
+  | `full_rollout=True` | 223 ms (~1.9x) | 116 ms (~2.0x) | 0.753 (+4%) | 0.519 (+4%) |
+  | `dynamic_padding=True` | 44 ms (~9x) | 30 ms (~8x) | 0.734 (+1.5%) | 0.508 (+2%) |
+
+  The speedup from `dynamic_padding` shrinks as your context approaches the full 2,048 steps, and the accuracy cost of `full_rollout` grows with the prediction length. More detailed analysis and full setup can be seen in: [PR #34](https://github.com/NX-AI/tirex/pull/34).
+
   For detailed instructions on optimization, please refer to the API.
   If you are interested in optimizing TiRex for dedicated hardware platforms (especially for edge or embedded use cases), please get in touch: [contact@nx-ai.com](mailto:contact@nx-ai.com)
 </details>

--- a/docs/content/getting-started/faqs.md
+++ b/docs/content/getting-started/faqs.md
@@ -21,6 +21,7 @@ In the following section, we address common questions and potential issues you m
   - Enable model compilation when loading the model.
   - Use hardware acceleration devices like CUDA (for NVIDIA GPUs) or MPS (for Apple Silicon) whenever possible.
   - For maximum speed, consider using our custom backends.
+  - Trade accuracy for speed with `model.forecast(..., full_rollout=True)` (predicts the whole horizon in one forward pass) or `dynamic_padding=True` (pads short contexts to the next patch instead of the full training context length). See the [forecasting workflow](../how-to/forecasting/workflow.md).
 
   For detailed instructions on optimization, please refer to the API.
   If you are interested in optimizing TiRex for dedicated hardware platforms (especially for edge or embedded use cases), please get in touch: [contact@nx-ai.com](mailto:contact@nx-ai.com)

--- a/docs/content/getting-started/faqs.md
+++ b/docs/content/getting-started/faqs.md
@@ -21,17 +21,17 @@ In the following section, we address common questions and potential issues you m
   - Enable model compilation when loading the model.
   - Use hardware acceleration devices like CUDA (for NVIDIA GPUs) or MPS (for Apple Silicon) whenever possible.
   - For maximum speed, consider using our custom backends.
-  - Trade accuracy for speed with `model.forecast(..., full_rollout=True)` (predicts the whole horizon in one forward pass) or `dynamic_padding=True` (pads short contexts to the next patch instead of the full training context length). See the [forecasting workflow](../how-to/forecasting/workflow.md).
+  - Trade some accuracy for speed with `full_rollout=True` or `dynamic_padding=True`. See the [forecasting workflow](../how-to/forecasting/workflow.md).
 
-  A quick estimation of the speed–accuracy trade-off (Setting: batch size 5, context length 128, prediction length 64, `torch` backend, average of 50 calls; lower MASE and CRPS values are better):
+  Example results for batch size 5, context length 128, and prediction length 64 using the `torch` backend (50-call average; lower MASE and CRPS are better):
 
   | Option | CPU | GPU | MASE (GiftEval) | CRPS (GiftEval) |
   | --- | --- | --- | --- | --- |
-  | Default (both off) | 416 ms | 233 ms | 0.724 | 0.499 |
-  | `full_rollout=True` | 223 ms (~1.9x) | 116 ms (~2.0x) | 0.753 (+4%) | 0.519 (+4%) |
-  | `dynamic_padding=True` | 44 ms (~9x) | 30 ms (~8x) | 0.734 (+1.5%) | 0.508 (+2%) |
+  | Default | 416 ms | 233 ms | 0.724 | 0.499 |
+  | `full_rollout` | 223 ms (1.9×) | 116 ms (2.0×) | 0.753 (+4%) | 0.519 (+4%) |
+  | `dynamic_padding` | 44 ms (9×) | 30 ms (8×) | 0.734 (+1.5%) | 0.508 (+2%) |
 
-  The speedup from `dynamic_padding` shrinks as your context approaches the full 2,048 steps, and the accuracy cost of `full_rollout` grows with the prediction length. More detailed analysis and the full setup are available in [PR #34](https://github.com/NX-AI/tirex/pull/34).
+  `dynamic_padding` helps less near the 2,048-step context limit, while `full_rollout` loses more accuracy at longer prediction lengths. See [PR #34](https://github.com/NX-AI/tirex/pull/34) for details.
 
   For detailed instructions on optimization, please refer to the API.
   If you are interested in optimizing TiRex for dedicated hardware platforms (especially for edge or embedded use cases), please get in touch: [contact@nx-ai.com](mailto:contact@nx-ai.com)

--- a/docs/content/getting-started/faqs.md
+++ b/docs/content/getting-started/faqs.md
@@ -23,15 +23,15 @@ In the following section, we address common questions and potential issues you m
   - For maximum speed, consider using our custom backends.
   - Trade accuracy for speed with `model.forecast(..., full_rollout=True)` (predicts the whole horizon in one forward pass) or `dynamic_padding=True` (pads short contexts to the next patch instead of the full training context length). See the [forecasting workflow](../how-to/forecasting/workflow.md).
 
-  A quick estimation of the speed–accuracy trade-off (Setting: batch size 5, context length 128, prediction length 64, `torch` backend, average of 50 calls; MASE and CRPS are lower-is-better):
+  A quick estimation of the speed–accuracy trade-off (Setting: batch size 5, context length 128, prediction length 64, `torch` backend, average of 50 calls; lower MASE and CRPS values are better):
 
-  | Option | CPU | GPU | MASE (Gifteval) | CRPS (Gifteval) |
+  | Option | CPU | GPU | MASE (GiftEval) | CRPS (GiftEval) |
   | --- | --- | --- | --- | --- |
   | Default (both off) | 416 ms | 233 ms | 0.724 | 0.499 |
   | `full_rollout=True` | 223 ms (~1.9x) | 116 ms (~2.0x) | 0.753 (+4%) | 0.519 (+4%) |
   | `dynamic_padding=True` | 44 ms (~9x) | 30 ms (~8x) | 0.734 (+1.5%) | 0.508 (+2%) |
 
-  The speedup from `dynamic_padding` shrinks as your context approaches the full 2,048 steps, and the accuracy cost of `full_rollout` grows with the prediction length. More detailed analysis and full setup can be seen in: [PR #34](https://github.com/NX-AI/tirex/pull/34).
+  The speedup from `dynamic_padding` shrinks as your context approaches the full 2,048 steps, and the accuracy cost of `full_rollout` grows with the prediction length. More detailed analysis and the full setup are available in [PR #34](https://github.com/NX-AI/tirex/pull/34).
 
   For detailed instructions on optimization, please refer to the API.
   If you are interested in optimizing TiRex for dedicated hardware platforms (especially for edge or embedded use cases), please get in touch: [contact@nx-ai.com](mailto:contact@nx-ai.com)

--- a/docs/content/how-to/forecasting/workflow.md
+++ b/docs/content/how-to/forecasting/workflow.md
@@ -35,15 +35,15 @@ model = load_model("NX-AI/TiRex")
 quantiles, mean = model.forecast(
     context,                 # tensor/array [batch, time]
     prediction_length=64,    # number of steps to forecast
-    full_rollout=False,      # predict the whole horizon in one forward pass
-    dynamic_padding=False,   # pad the context to the next patch instead of the full training context
+    full_rollout=False,      # when True, predict the horizon in one forward pass
+    dynamic_padding=False,   # when True, pad the context to the next patch multiple only
 )
 ```
 
 - **Quantiles**: by default nine quantiles (0.1…0.9) as reported in the paper are returned.
 - **Batching**: large batches improve throughput; keep an eye on memory if prediction length is long.
-- **`full_rollout`**: TiRex forecasts in patches of 32 steps. By default a longer horizon is rolled out one patch per forward pass; with `full_rollout=True` the whole horizon comes out of a single pass. Faster for long horizons, but forecast quality might degrade as the horizon grows.
-- **`dynamic_padding`**: by default the context is padded to the full training context length (2,048 steps) before every forward pass. With `dynamic_padding=True` it is padded only to the next multiple of the patch size, which is markedly faster for short histories. Forecasting quality might degrade, so check accuracy on your data before enabling it.
+- **`full_rollout`**: TiRex forecasts in patches of 32 steps. By default a longer horizon is rolled out one patch per forward pass. Set to `True` to predict the entire horizon in a single forward pass. Faster for long horizons, but forecast quality might degrade as the horizon grows.
+- **`dynamic_padding`**: by default the context is padded to the full training context length (2,048 steps) before every forward pass. Set to `True` to pad the context only to the next multiple of the patch size. Markedly faster for short contexts, but forecasting quality might degrade.
 
 Both options default to the standard behaviour and are available on `forecast`, `forecast_gluon`, and `forecast_hfdata`.
 

--- a/docs/content/how-to/forecasting/workflow.md
+++ b/docs/content/how-to/forecasting/workflow.md
@@ -35,11 +35,17 @@ model = load_model("NX-AI/TiRex")
 quantiles, mean = model.forecast(
     context,                 # tensor/array [batch, time]
     prediction_length=64,    # number of steps to forecast
+    full_rollout=False,      # predict the whole horizon in one forward pass
+    dynamic_padding=False,   # pad the context to the next patch instead of the full training context
 )
 ```
 
 - **Quantiles**: by default nine quantiles (0.1…0.9) as reported in the paper are returned.
 - **Batching**: large batches improve throughput; keep an eye on memory if prediction length is long.
+- **`full_rollout`**: TiRex forecasts in patches of 32 steps. By default a longer horizon is rolled out one patch per forward pass; with `full_rollout=True` the whole horizon comes out of a single pass. Faster for long horizons, but forecast quality might degrade as the horizon grows.
+- **`dynamic_padding`**: by default the context is padded to the full training context length (2,048 steps) before every forward pass. With `dynamic_padding=True` it is padded only to the next multiple of the patch size, which is markedly faster for short histories. Forecasting quality might degrade, so check accuracy on your data before enabling it.
+
+Both options default to the standard behaviour and are available on `forecast`, `forecast_gluon`, and `forecast_hfdata`.
 
 ## 4. Evaluate
 

--- a/src/tirex/api_adapter/forecast.py
+++ b/src/tirex/api_adapter/forecast.py
@@ -243,7 +243,7 @@ class ForecastModel(ABC):
             dynamic_padding (bool, optional): How the context is padded before each forward pass:
                 - `False`: The context is padded to the full training context length.
                 - `True`: The context is padded to the smallest multiple of the patch size that fits it.
-                  This is faster for contexts shorter than the training context length, but but forecasting quality might degrade.
+                  This is faster for contexts shorter than the training context length, but forecasting quality might degrade.
                 Defaults to `False`.
 
             **predict_kwargs: Additional keyword arguments that are passed directly to the underlying
@@ -322,7 +322,7 @@ class ForecastModel(ABC):
             dynamic_padding (bool, optional): How the context is padded before each forward pass:
                 - `False`: The context is padded to the full training context length.
                 - `True`: The context is padded to the smallest multiple of the patch size that fits it.
-                    This is faster for contexts shorter than the training context length, but but forecasting quality might degrade.
+                    This is faster for contexts shorter than the training context length, but forecasting quality might degrade.
                 Defaults to `False`.
 
             **predict_kwargs: Additional keyword arguments that are passed directly to the underlying
@@ -406,7 +406,7 @@ class ForecastModel(ABC):
             dynamic_padding (bool, optional): How the context is padded before each forward pass:
                 - `False`: The context is padded to the full training context length.
                 - `True`: The context is padded to the smallest multiple of the patch size that fits it.
-                    This is faster for contexts shorter than the training context length, but but forecasting quality might degrade.
+                    This is faster for contexts shorter than the training context length, but forecasting quality might degrade.
                 Defaults to `False`.
 
             **predict_kwargs: Additional keyword arguments that are passed directly to the underlying

--- a/src/tirex/api_adapter/forecast.py
+++ b/src/tirex/api_adapter/forecast.py
@@ -209,6 +209,8 @@ class ForecastModel(ABC):
         batch_size: int = 512,
         yield_per_batch: bool = False,
         resample_strategy: Literal["frequency"] | None = None,
+        full_rollout: bool = False,
+        dynamic_padding: bool = False,
         **predict_kwargs,
     ):
         """
@@ -231,6 +233,18 @@ class ForecastModel(ABC):
 
             resample_strategy (Optional[str], optional): Choose a resampling strategy. Allowed values: "frequency".
                                                 If `None`, no resampling is applied. Currently only "frequency" is supported.
+
+            full_rollout (bool, optional): How the forecast horizon is generated:
+                - `False`: One patch is predicted per forward pass.
+                - `True`: The whole horizon is predicted in a single forward pass. This is faster for
+                  horizons longer than one patch, but forecasting quality might degrade as the horizon grows.
+                Defaults to `False`.
+
+            dynamic_padding (bool, optional): How the context is padded before each forward pass:
+                - `False`: The context is padded to the full training context length.
+                - `True`: The context is padded to the smallest multiple of the patch size that fits it.
+                  This is faster for contexts shorter than the training context length, but but forecasting quality might degrade.
+                Defaults to `False`.
 
             **predict_kwargs: Additional keyword arguments that are passed directly to the underlying
                               prediction mechanism of the pre-trained model. Refer to the model's
@@ -261,6 +275,8 @@ class ForecastModel(ABC):
             yield_per_batch,
             resample_strategy=resample_strategy,
             max_context=self.max_context_length,
+            full_rollout=full_rollout,
+            dynamic_padding=dynamic_padding,
             **predict_kwargs,
         )
 
@@ -272,6 +288,8 @@ class ForecastModel(ABC):
         yield_per_batch: bool = False,
         resample_strategy: Literal["frequency"] | None = None,
         data_kwargs: dict = {},
+        full_rollout: bool = False,
+        dynamic_padding: bool = False,
         **predict_kwargs,
     ):
         """
@@ -294,6 +312,18 @@ class ForecastModel(ABC):
 
             resample_strategy (Optional[str], optional): Choose a resampling strategy. Allowed values: "frequency".
                                                 If `None`, no resampling is applied. Currently only "frequency" is supported.
+
+            full_rollout (bool, optional): How the forecast horizon is generated:
+                - `False`: One patch is predicted per forward pass.
+                - `True`: The whole horizon is predicted in a single forward pass. This is faster for
+                    horizons longer than one patch, but forecasting quality might degrade as the horizon grows.
+                Defaults to `False`.
+
+            dynamic_padding (bool, optional): How the context is padded before each forward pass:
+                - `False`: The context is padded to the full training context length.
+                - `True`: The context is padded to the smallest multiple of the patch size that fits it.
+                    This is faster for contexts shorter than the training context length, but but forecasting quality might degrade.
+                Defaults to `False`.
 
             **predict_kwargs: Additional keyword arguments that are passed directly to the underlying
                               prediction mechanism of the pre-trained model. Refer to the model's
@@ -329,6 +359,8 @@ class ForecastModel(ABC):
             yield_per_batch,
             resample_strategy=resample_strategy,
             max_context=self.max_context_length,
+            full_rollout=full_rollout,
+            dynamic_padding=dynamic_padding,
             **predict_kwargs,
         )
 
@@ -340,6 +372,8 @@ class ForecastModel(ABC):
         yield_per_batch: bool = False,
         resample_strategy: Literal["frequency"] | None = None,
         data_kwargs: dict = {},
+        full_rollout: bool = False,
+        dynamic_padding: bool = False,
         **predict_kwargs,
     ):
         """
@@ -362,6 +396,18 @@ class ForecastModel(ABC):
 
             resample_strategy (Optional[str], optional): Choose a resampling strategy. Allowed values: "frequency".
                                                 If `None`, no resampling is applied. Currently only "frequency" is supported.
+
+            full_rollout (bool, optional): How the forecast horizon is generated:
+                - `False`: One patch is predicted per forward pass.
+                - `True`: The whole horizon is predicted in a single forward pass. This is faster for
+                    horizons longer than one patch, but forecasting quality might degrade as the horizon grows.
+                Defaults to `False`.
+
+            dynamic_padding (bool, optional): How the context is padded before each forward pass:
+                - `False`: The context is padded to the full training context length.
+                - `True`: The context is padded to the smallest multiple of the patch size that fits it.
+                    This is faster for contexts shorter than the training context length, but but forecasting quality might degrade.
+                Defaults to `False`.
 
             **predict_kwargs: Additional keyword arguments that are passed directly to the underlying
                               prediction mechanism of the pre-trained model. Refer to the model's
@@ -399,5 +445,7 @@ class ForecastModel(ABC):
             yield_per_batch,
             resample_strategy=resample_strategy,
             max_context=self.max_context_length,
+            full_rollout=full_rollout,
+            dynamic_padding=dynamic_padding,
             **predict_kwargs,
         )

--- a/src/tirex/models/slstm/cell.py
+++ b/src/tirex/models/slstm/cell.py
@@ -141,10 +141,8 @@ class sLSTMCellTorch:
         output = []
         for i in range(S):
             Ry = (
-                states[0]
-                .reshape(B, num_heads, 1, -1)
-                .matmul(R.unsqueeze(0))
-                .reshape(B, num_heads, num_gates, -1)
+                torch.einsum("bhd,hdn->bhn", states[0].view(B, num_heads, -1), R)
+                .view(B, num_heads, num_gates, -1)
                 .transpose(1, 2)
                 .reshape(B, -1)
             )

--- a/src/tirex/models/tirex.py
+++ b/src/tirex/models/tirex.py
@@ -2,6 +2,7 @@
 # This software may be used and distributed according to the terms of the NXAI Community License Agreement.
 
 import logging
+import math
 from dataclasses import dataclass
 
 import torch
@@ -83,12 +84,24 @@ class TiRexZero(nn.Module, PretrainedModel, ForecastModel):
         context: torch.Tensor,
         prediction_length: int | None = None,
         output_device: str = "cpu",
-        max_accelerated_rollout_steps: int = 1,
+        full_rollout: bool = False,
+        dynamic_padding: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         device = self.input_patch_embedding.hidden_layer.weight.device
         context = context.to(device)
 
-        quantiles = self._forecast_tensor(context, prediction_length, new_patch_count=max_accelerated_rollout_steps)
+        max_accelerated_rollout_steps = (
+            math.ceil((prediction_length or self.tokenizer.patch_size) / self.tokenizer.patch_size)
+            if full_rollout
+            else 1
+        )
+
+        quantiles = self._forecast_tensor(
+            context,
+            prediction_length,
+            new_patch_count=max_accelerated_rollout_steps,
+            dynamic_padding=dynamic_padding,
+        )
         quantiles = quantiles.to(torch.device(output_device)).swapaxes(1, 2)
 
         mean = quantiles[:, :, self.config.quantiles.index(0.5)].squeeze(-1)  # median as mean
@@ -99,6 +112,7 @@ class TiRexZero(nn.Module, PretrainedModel, ForecastModel):
         context: torch.Tensor,
         prediction_length: int | None = None,
         new_patch_count: int = 1,
+        dynamic_padding: bool = False,
     ) -> torch.Tensor:
         predictions = []
         if prediction_length is None:
@@ -111,7 +125,7 @@ class TiRexZero(nn.Module, PretrainedModel, ForecastModel):
         context = context.to(dtype=torch.float32)
         while remaining > 0:
             new_patch_count = min(remaining, new_patch_count)
-            prediction = self._forecast_single_step(context, new_patch_count)
+            prediction = self._forecast_single_step(context, new_patch_count, dynamic_padding=dynamic_padding)
 
             predictions.append(prediction)
             remaining -= new_patch_count
@@ -123,9 +137,19 @@ class TiRexZero(nn.Module, PretrainedModel, ForecastModel):
 
         return torch.cat(predictions, dim=-1)[..., :prediction_length].to(dtype=torch.float32)
 
-    def _forecast_single_step(self, context: torch.Tensor, new_patch_count: int = 1) -> torch.Tensor:
-        max_context, min_context = self.config.train_ctx_len, self.config.train_ctx_len
-        context, _ = self._adjust_context_length(context, max_context, min_context)
+    def _forecast_single_step(
+        self, context: torch.Tensor, new_patch_count: int = 1, dynamic_padding: bool = False
+    ) -> torch.Tensor:
+        max_context = self.config.train_ctx_len
+        if dynamic_padding:
+            # pad only up to the smallest multiple of the patch size that fits the actual context
+            min_context = min(
+                max_context, math.ceil(context.shape[-1] / self.tokenizer.patch_size) * self.tokenizer.patch_size
+            )
+        else:
+            min_context = max_context
+
+        context, _ = self._adjust_context_length(context, min_context, max_context)
         input_token, tokenizer_state = self.tokenizer.input_transform(context)
         prediction = self._forward_model_tokenized(input_token=input_token, new_patch_count=new_patch_count)
         predicted_token = prediction[:, :, -new_patch_count:, :].to(input_token)  # predicted token

--- a/tests/test_chronos_zs.py
+++ b/tests/test_chronos_zs.py
@@ -20,7 +20,7 @@ def geometric_mean(s):
 def eval_task(model, task):
     inference_time = 0.0
     predictions_per_window = []
-    for window in task.iter_windows(trust_remote_code=True):
+    for window in task.iter_windows():
         past_data, _ = fev.convert_input_data(window, adapter="datasets", as_univariate=True)
         past_data = past_data.with_format("torch").cast_column("target", datasets.Sequence(datasets.Value("float32")))
         loaded_targets = [t for t in past_data["target"]]

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -57,3 +57,54 @@ def test_forecast_seattle_5T(tirex_model, resample_strategy, ref_mean_path, ref_
     # default rtol & atol for bfloat16
     torch.testing.assert_close(mean, ref_mean, rtol=1.6e-2, atol=1e-5)
     torch.testing.assert_close(quantiles, ref_quantiles, rtol=1.6e-2, atol=1e-5)
+
+
+def test_full_rollout_is_a_no_op_within_one_patch(tirex_model):
+    context = load_tensor_from_txt_file("air_passengers.csv")[:-12]
+    patch_size = tirex_model.tokenizer.patch_size
+
+    quantiles, mean = tirex_model.forecast(context, prediction_length=patch_size)
+    quantiles_full, mean_full = tirex_model.forecast(context, prediction_length=patch_size, full_rollout=True)
+
+    # a single patch already covers the horizon, so both settings run the same single forward pass
+    assert torch.equal(quantiles_full, quantiles)
+    assert torch.equal(mean_full, mean)
+
+
+def test_full_rollout_over_multiple_patches(tirex_model):
+    context = load_tensor_from_txt_file("air_passengers.csv")[:-12]
+    prediction_length = 3 * tirex_model.tokenizer.patch_size
+
+    quantiles, mean = tirex_model.forecast(context, prediction_length=prediction_length)
+    quantiles_full, mean_full = tirex_model.forecast(context, prediction_length=prediction_length, full_rollout=True)
+
+    assert quantiles_full.shape == quantiles.shape
+    assert mean_full.shape == mean.shape
+    assert torch.isfinite(quantiles_full).all()
+    # the horizon is predicted in one pass instead of three, which changes the forecast
+    assert not torch.equal(quantiles_full, quantiles)
+
+
+def test_dynamic_padding_shortens_the_padded_context(tirex_model):
+    context = load_tensor_from_txt_file("air_passengers.csv")[:-12]
+
+    quantiles, mean = tirex_model.forecast(context, prediction_length=24)
+    quantiles_dyn, mean_dyn = tirex_model.forecast(context, prediction_length=24, dynamic_padding=True)
+
+    assert quantiles_dyn.shape == quantiles.shape
+    assert mean_dyn.shape == mean.shape
+    assert torch.isfinite(quantiles_dyn).all()
+    # the context is padded to the next multiple of the patch size instead of the training context
+    # length, so the model sees fewer masked tokens and the forecast changes
+    assert not torch.equal(quantiles_dyn, quantiles)
+
+
+def test_dynamic_padding_is_a_no_op_for_a_full_context(tirex_model):
+    context = load_tensor_from_txt_file("loop_seattle_5T.csv")[: tirex_model.config.train_ctx_len]
+
+    quantiles, mean = tirex_model.forecast(context, prediction_length=24)
+    quantiles_dyn, mean_dyn = tirex_model.forecast(context, prediction_length=24, dynamic_padding=True)
+
+    # the context already fills the training context length, so there is nothing to pad
+    assert torch.equal(quantiles_dyn, quantiles)
+    assert torch.equal(mean_dyn, mean)

--- a/tests/test_forecast_adapter.py
+++ b/tests/test_forecast_adapter.py
@@ -1,6 +1,8 @@
 # Copyright (c) NXAI GmbH.
 # This software may be used and distributed according to the terms of the NXAI Community License Agreement.
 
+import inspect
+
 import numpy as np
 import pytest
 import torch
@@ -94,3 +96,33 @@ def test_forecast_iterator_mode():
         else:
             assert q.shape == (1, 10, 9)
             assert m.shape == (1, 10)
+
+
+# ----- Tests: forecast options -----
+class OptionRecordingForecaster(ForecastModel):
+    def __init__(self):
+        self.seen_kwargs = []
+
+    def _forecast_quantiles(self, batch: torch.Tensor, **kwargs):
+        self.seen_kwargs.append(kwargs)
+        return fc_random_from_tensor(batch, **kwargs)
+
+
+def test_forecast_option_defaults_are_forwarded():
+    model = OptionRecordingForecaster()
+    model.forecast(torch.rand((2, 20)), prediction_length=10)
+    assert model.seen_kwargs == [{"prediction_length": 10, "full_rollout": False, "dynamic_padding": False}]
+
+
+def test_forecast_options_are_forwarded():
+    model = OptionRecordingForecaster()
+    model.forecast(torch.rand((2, 20)), prediction_length=10, full_rollout=True, dynamic_padding=True)
+    assert model.seen_kwargs == [{"prediction_length": 10, "full_rollout": True, "dynamic_padding": True}]
+
+
+@pytest.mark.parametrize("fc_method", ["forecast", "forecast_gluon", "forecast_hfdata"])
+@pytest.mark.parametrize("option", ["full_rollout", "dynamic_padding"])
+def test_forecast_options_are_public_parameters(fc_method, option):
+    parameter = inspect.signature(getattr(ForecastModel, fc_method)).parameters.get(option)
+    assert parameter is not None, f"{fc_method} does not expose {option}"
+    assert parameter.default is False


### PR DESCRIPTION
## Changes

As suggested by @daidahao, this PR adds two optional forecasting speed improvements and one fixed speed improvement:

- `full_rollout` — predict the full horizon in one forward pass.
- `dynamic_padding` — pad only to the next patch multiple instead of always to 2,048 steps.
- Replace the recurrent `R` reshape + `matmul` with `einsum` in `sLSTMCellTorch`.

It also updates the Chronos zero-shot test for the current FEV API by removing the obsolete `trust_remote_code` argument.

## Reason

The three forecasting changes provide significant inference speedups.

## Tests & docs

- 12 new tests covering option forwarding and model behavior.
- Updated forecasting docs and the “forecasts running slowly” FAQ.
- Fixed the FEV compatibility failure reported by [this GitHub Actions job](https://github.com/NX-AI/tirex/actions/runs/33482816043/job/99776025204).

## Performance Analysis

### Settings

- **Batch size:** 5
- **Context length:** 128
- **Prediction length:** 64
- **Backend:** `torch`
- **Testing:** All changes were tested separately
- **Environment:** Python 3.11, Linux

---

## 1. Tirex-1 — Main Branch

### A) Profiling

| Total ms | Avg ms | N | Op | Source | Via |
|---:|---:|---:|---|---|---|
| 122.0 | 0.0794 | 1536 | `aten::bmm` | `slstm/cell.py(146)` | `aten::matmul` |
| 98.8 | 0.0643 | 1536 | `aten::copy_` | `slstm/cell.py(146)` | `aten::clone <- aten::reshape` |
| 15.9 | 0.0017 | 9216 | `aten::copy_` | `slstm/cell.py(156)` | `aten::_to_copy <- aten::to` |
| 6.6 | 0.0011 | 6144 | `aten::copy_` | `slstm/cell.py(158)` | `aten::_to_copy <- aten::to` |
| 5.1 | 0.0034 | 1536 | `aten::copy_` | `slstm/cell.py(149)` | `aten::clone <- aten::reshape` |

### B) Inference Speed

Average of 50 inference calls:

- **CPU:** 415.5 ms per forecast
- **CUDA:** 233.4 ms per forecast

### C) Gifteval Results

- **MASE:** 0.7236
- **CRPS:** 0.4985

---

## 2. Optimization 1 — Roll Out Once

### A) Profiling

The number of `bmm` and `copy` operations is reduced by a factor of 2.

| Total ms | Avg ms | N | Op | Source | Via |
|---:|---:|---:|---|---|---|
| 65.0 | 0.0833 | 780 | `aten::bmm` | `slstm/cell.py(146)` | `aten::matmul` |
| 59.6 | 0.0764 | 780 | `aten::copy_` | `slstm/cell.py(146)` | `aten::clone <- aten::reshape` |
| 8.5 | 0.0018 | 4680 | `aten::copy_` | `slstm/cell.py(156)` | `aten::_to_copy <- aten::to` |
| 3.8 | 0.0012 | 3120 | `aten::copy_` | `slstm/cell.py(158)` | `aten::_to_copy <- aten::to` |
| 3.1 | 0.0040 | 780 | `aten::copy_` | `slstm/cell.py(149)` | `aten::clone <- aten::reshape` |

### B) Inference Speed

Average of 50 inference calls:

- **CPU:** 222.5 ms per forecast
- **CUDA:** 116.2 ms per forecast

This results in approximately a 2× speedup compared to the main branch.

### C) Difference from Original Forecasting

With the same input, differences are observed on both CPU and GPU:

- **cpu_torch:** max abs diff quantiles `9.783e-02`, mean `7.884e-02`
- **cuda_torch:** max abs diff quantiles `9.692e-02`, mean `7.410e-02`

### D) Gifteval Results

The modified implementation performs worse on the Gifteval benchmark:

- **MASE:** 0.7533
- **CRPS:** 0.5189

---

## 3. Optimization 2 — Shorten the Context

### A) Profiling

There is a significant decrease in the number of operations.

| Total ms | Avg ms | N | Op | Source | Via |
|---:|---:|---:|---|---|---|
| 9.3 | 0.0865 | 108 | `aten::bmm` | `slstm/cell.py(146)` | `aten::matmul` |
| 7.6 | 0.0703 | 108 | `aten::copy_` | `slstm/cell.py(146)` | `aten::clone <- aten::reshape` |
| 1.9 | 0.0194 | 96 | `aten::bmm` | `slstm/layer.py(47)` | `aten::einsum` |
| 0.9 | 0.2254 | 4 | `aten::copy_` | `models/tirex.py(243)` | `aten::addmm <- aten::linear` |
| 0.9 | 0.0014 | 648 | `aten::copy_` | `slstm/cell.py(156)` | `aten::_to_copy <- aten::to` |

### B) Inference Speed

Average of 50 inference calls:

- **CPU:** 44.2 ms per forecast
- **CUDA:** 29.5 ms per forecast

### C) Difference from Original Forecasting

There are significant differences in forecasting results on both CPU and GPU:

- **cpu_torch:** max abs diff quantiles `1.049e+00`, mean `6.962e-01`
- **cuda_torch:** max abs diff quantiles `1.053e+00`, mean `6.985e-01`

### D) Gifteval Results

- **MASE:** 0.7344
- **CRPS:** 0.5083

---

## 4. Optimization 3 — Avoiding Copy of Matrix R

### A) Profiling

This improves the efficiency of the `bmm` and `copy` operations.

| Total ms | Avg ms | N | Op | Source | Via |
|---:|---:|---:|---|---|---|
| 59.7 | 0.0389 | 1536 | `aten::bmm` | `slstm/cell.py(152)` | `aten::einsum` |
| 13.9 | 0.0015 | 9216 | `aten::copy_` | `slstm/cell.py(156)` | `aten::_to_copy <- aten::to` |
| 5.1 | 0.0008 | 6144 | `aten::copy_` | `slstm/cell.py(158)` | `aten::_to_copy <- aten::to` |
| 4.8 | 0.0500 | 96 | `aten::bmm` | `slstm/layer.py(47)` | `aten::einsum` |
| 3.6 | 0.0024 | 1536 | `aten::copy_` | `slstm/cell.py(153)` | `aten::clone <- aten::reshape` |

### B) Inference Speed

Average of 50 inference calls:

- **CPU:** 274.5 ms per forecast
- **CUDA:** 235.9 ms per forecast

This gives a speed reduction by 1.5 on CPU, with no improvements on GPU.

### C) Difference from Original Forecasting

- **cpu_torch:** max abs diff quantiles `0.000e+00`, mean `0.000e+00`
- **cuda_torch:** max abs diff quantiles `1.404e-02`, mean `1.141e-02`

### D) Gifteval Results

Results are similar to the original implementation:

- **MASE:** 0.7237
- **CRPS:** 0.4985