### PR TITLE
Optimization improvements

### DIFF
--- a/src/tirex/models/slstm/cell.py
+++ b/src/tirex/models/slstm/cell.py
@@ -139,12 +139,17 @@ class sLSTMCellTorch:
 
         states = states.to(R.dtype).unbind(dim=0)
         output = []
+        head_dim = R.shape[1]
+
         for i in range(S):
             Ry = (
-                torch.einsum("bhd,hdn->bhn", states[0].view(B, num_heads, -1), R)
-                .view(B, num_heads, num_gates, -1)
-                .transpose(1, 2)
-                .reshape(B, -1)
+                states[0]
+                .view(B, num_heads, head_dim)
+                .transpose(0, 1)  
+                .bmm(R) 
+                .view(num_heads, B, num_gates, head_dim)
+                .permute(1, 2, 0, 3)  
+                .reshape(B, -1) 
             )
             states = sLSTMCellTorch.slstm_forward_pointwise(
                 x[i].float(), Ry.float(), b.float(), [s.float() for s in states]

--- a/src/tirex/models/slstm/cell.py
+++ b/src/tirex/models/slstm/cell.py
@@ -170,7 +170,7 @@ class sLSTMCellTorch:
         Ry: torch.Tensor,  # dim [B, 4*H]
         b: torch.Tensor,  # dim [1, 4*H]
         states: torch.Tensor,  # dim 4 x [B, H]
-        n_all_zero: bool | None = None, 
+        n_all_zero: bool, 
     ) -> list[torch.Tensor]:
         y, c, n, m = states
 
@@ -178,9 +178,8 @@ class sLSTMCellTorch:
         iraw, fraw, zraw, oraw = torch.unbind(raw.view(raw.shape[0], 4, -1), dim=1)
 
         # Equations reference the xlstm paper on page 4: https://arxiv.org/pdf/2405.04517
-        logfplusm = m + F.logsigmoid(torch.clamp(fraw, max=15))  # eq 15 # Clamp to avoid subnomals
-        if n_all_zero is None:  
-            n_all_zero = bool(torch.all(n == 0.0))
+        logfplusm = m + F.logsigmoid(torch.clamp(fraw, max=15))  # eq 15 # Clamp to avoid subnomals 
+        
         mnew = iraw if n_all_zero else torch.max(iraw, logfplusm)  # eq 15
         ogate = torch.sigmoid(oraw)  # eq 14
         igate = torch.exp(torch.clamp(iraw - mnew, max=0))  # eq 16

--- a/src/tirex/models/slstm/cell.py
+++ b/src/tirex/models/slstm/cell.py
@@ -141,7 +141,7 @@ class sLSTMCellTorch:
         head_dim = R.shape[1]
 
         b = b.float()
-        n_all_zero = bool(torch.all(n == 0.0))
+        n_all_zero = torch.all(n == 0.0)
 
         output = x.new_empty((S, B, H), dtype=R.dtype)
         for i in range(S):
@@ -158,7 +158,7 @@ class sLSTMCellTorch:
                 Ry.float(),
                 b,
                 [y, c.float(), n.float(), m.float()],
-                n_all_zero=n_all_zero and i == 0,
+                n_all_zero=n_all_zero if i == 0 else None,
             )
 
             y, c, n, m = (t.to(dtype=R.dtype) for t in (y, c, n, m))
@@ -172,7 +172,7 @@ class sLSTMCellTorch:
         Ry: torch.Tensor,  # dim [B, 4*H]
         b: torch.Tensor,  # dim [1, 4*H]
         states: torch.Tensor,  # dim 4 x [B, H]
-        n_all_zero: bool,
+        n_all_zero: torch.Tensor | None,
     ) -> list[torch.Tensor]:
         y, c, n, m = states
 
@@ -182,7 +182,10 @@ class sLSTMCellTorch:
         # Equations reference the xlstm paper on page 4: https://arxiv.org/pdf/2405.04517
         logfplusm = m + F.logsigmoid(torch.clamp(fraw, max=15))  # eq 15 # Clamp to avoid subnomals
 
-        mnew = iraw if n_all_zero else torch.max(iraw, logfplusm)  # eq 15
+        if n_all_zero is None:
+            mnew = torch.max(iraw, logfplusm)  # eq 15
+        else:
+            mnew = torch.where(n_all_zero, iraw, torch.max(iraw, logfplusm))  # eq 15
         ogate = torch.sigmoid(oraw)  # eq 14
         igate = torch.exp(torch.clamp(iraw - mnew, max=0))  # eq 16
         fgate = torch.exp(torch.clamp(logfplusm - mnew, max=0))  # eq 17

--- a/src/tirex/models/slstm/cell.py
+++ b/src/tirex/models/slstm/cell.py
@@ -179,7 +179,7 @@ class sLSTMCellTorch:
 
         # Equations reference the xlstm paper on page 4: https://arxiv.org/pdf/2405.04517
         logfplusm = m + F.logsigmoid(torch.clamp(fraw, max=15))  # eq 15 # Clamp to avoid subnomals
-        if n_all_zero is None:  # a caller that predates this argument
+        if n_all_zero is None:  
             n_all_zero = bool(torch.all(n == 0.0))
         mnew = iraw if n_all_zero else torch.max(iraw, logfplusm)  # eq 15
         ogate = torch.sigmoid(oraw)  # eq 14

--- a/src/tirex/models/slstm/cell.py
+++ b/src/tirex/models/slstm/cell.py
@@ -137,13 +137,16 @@ class sLSTMCellTorch:
         H = R.shape[1] * num_heads
         assert states.shape == (num_gates, B, H)
 
-        states = states.to(R.dtype).unbind(dim=0)
-        output = []
+        y, c, n, m = states.to(R.dtype).unbind(dim=0)
         head_dim = R.shape[1]
 
+        b = b.float()
+        n_all_zero = bool(torch.all(n == 0.0))
+
+        output = x.new_empty((S, B, H), dtype=R.dtype)
         for i in range(S):
             Ry = (
-                states[0]
+                y
                 .view(B, num_heads, head_dim)
                 .transpose(0, 1)  
                 .bmm(R) 
@@ -151,13 +154,15 @@ class sLSTMCellTorch:
                 .permute(1, 2, 0, 3)  
                 .reshape(B, -1) 
             )
-            states = sLSTMCellTorch.slstm_forward_pointwise(
-                x[i].float(), Ry.float(), b.float(), [s.float() for s in states]
+            y, c, n, m = sLSTMCellTorch.slstm_forward_pointwise(
+                x[i].float(), Ry.float(), b, [y, c.float(), n.float(), m.float()],
+                n_all_zero=n_all_zero and i == 0,
             )
-            states = [s.to(dtype=R.dtype) for s in states]
-            output.append(states[0])
 
-        return torch.stack(output), torch.stack(states)  # (S, B, H), 4 x (B, H)
+            y, c, n, m = (t.to(dtype=R.dtype) for t in (y, c, n, m))
+            output[i] = y
+
+        return output, torch.stack([y,c,n,m])  # (S, B, H), 4 x (B, H)
 
     @staticmethod
     def slstm_forward_pointwise(
@@ -165,6 +170,7 @@ class sLSTMCellTorch:
         Ry: torch.Tensor,  # dim [B, 4*H]
         b: torch.Tensor,  # dim [1, 4*H]
         states: torch.Tensor,  # dim 4 x [B, H]
+        n_all_zero: bool | None = None, 
     ) -> list[torch.Tensor]:
         y, c, n, m = states
 
@@ -173,10 +179,12 @@ class sLSTMCellTorch:
 
         # Equations reference the xlstm paper on page 4: https://arxiv.org/pdf/2405.04517
         logfplusm = m + F.logsigmoid(torch.clamp(fraw, max=15))  # eq 15 # Clamp to avoid subnomals
-        mnew = torch.where(torch.all(n == 0.0), iraw, torch.max(iraw, logfplusm))  # eq 15
+        if n_all_zero is None:  # a caller that predates this argument
+            n_all_zero = bool(torch.all(n == 0.0))
+        mnew = iraw if n_all_zero else torch.max(iraw, logfplusm)  # eq 15
         ogate = torch.sigmoid(oraw)  # eq 14
-        igate = torch.minimum(torch.exp(iraw - mnew), torch.ones_like(iraw))  # eq 16
-        fgate = torch.minimum(torch.exp(logfplusm - mnew), torch.ones_like(iraw))  # eq 17
+        igate = torch.exp(torch.clamp(iraw - mnew, max=0))  # eq 16
+        fgate = torch.exp(torch.clamp(logfplusm - mnew,max=0))  # eq 17
         zgate = torch.tanh(zraw)  # eq 11
         cnew = fgate * c + igate * zgate  # eq 8
         nnew = fgate * n + igate  # eq 9

--- a/src/tirex/models/slstm/cell.py
+++ b/src/tirex/models/slstm/cell.py
@@ -146,23 +146,25 @@ class sLSTMCellTorch:
         output = x.new_empty((S, B, H), dtype=R.dtype)
         for i in range(S):
             Ry = (
-                y
-                .view(B, num_heads, head_dim)
-                .transpose(0, 1)  
-                .bmm(R) 
+                y.view(B, num_heads, head_dim)
+                .transpose(0, 1)
+                .bmm(R)
                 .view(num_heads, B, num_gates, head_dim)
-                .permute(1, 2, 0, 3)  
-                .reshape(B, -1) 
+                .permute(1, 2, 0, 3)
+                .reshape(B, -1)
             )
             y, c, n, m = sLSTMCellTorch.slstm_forward_pointwise(
-                x[i].float(), Ry.float(), b, [y, c.float(), n.float(), m.float()],
+                x[i].float(),
+                Ry.float(),
+                b,
+                [y, c.float(), n.float(), m.float()],
                 n_all_zero=n_all_zero and i == 0,
             )
 
             y, c, n, m = (t.to(dtype=R.dtype) for t in (y, c, n, m))
             output[i] = y
 
-        return output, torch.stack([y,c,n,m])  # (S, B, H), 4 x (B, H)
+        return output, torch.stack([y, c, n, m])  # (S, B, H), 4 x (B, H)
 
     @staticmethod
     def slstm_forward_pointwise(
@@ -170,7 +172,7 @@ class sLSTMCellTorch:
         Ry: torch.Tensor,  # dim [B, 4*H]
         b: torch.Tensor,  # dim [1, 4*H]
         states: torch.Tensor,  # dim 4 x [B, H]
-        n_all_zero: bool, 
+        n_all_zero: bool,
     ) -> list[torch.Tensor]:
         y, c, n, m = states
 
@@ -178,12 +180,12 @@ class sLSTMCellTorch:
         iraw, fraw, zraw, oraw = torch.unbind(raw.view(raw.shape[0], 4, -1), dim=1)
 
         # Equations reference the xlstm paper on page 4: https://arxiv.org/pdf/2405.04517
-        logfplusm = m + F.logsigmoid(torch.clamp(fraw, max=15))  # eq 15 # Clamp to avoid subnomals 
-        
+        logfplusm = m + F.logsigmoid(torch.clamp(fraw, max=15))  # eq 15 # Clamp to avoid subnomals
+
         mnew = iraw if n_all_zero else torch.max(iraw, logfplusm)  # eq 15
         ogate = torch.sigmoid(oraw)  # eq 14
         igate = torch.exp(torch.clamp(iraw - mnew, max=0))  # eq 16
-        fgate = torch.exp(torch.clamp(logfplusm - mnew,max=0))  # eq 17
+        fgate = torch.exp(torch.clamp(logfplusm - mnew, max=0))  # eq 17
         zgate = torch.tanh(zraw)  # eq 11
         cnew = fgate * c + igate * zgate  # eq 8
         nnew = fgate * n + igate  # eq 9


### PR DESCRIPTION
# PR 

## PR: what was done

In this PR I was trying to find a speed-up improvement inside sLSTMCell on the torch backend

Main changes:
- `torch.all(n == 0.0)` is now calculated once
- `b.float()` put outside of the loop
- usage of preallocated buffer instead of `list` + `torch.stack`


## Test settings

| | |
|---|---|
| **CPU** | AMD Ryzen Threadripper PRO 9985WX (64C/128T) |
| **GPU** | NVIDIA RTX PRO 6000 Blackwell Max-Q |
| **CPU Threads** | 16 |
| **PyTorch** |2.9.1+cu128 |
| **Batch Size** | 64 |
| **Context Length** | 1024 |
| **Prediction Length** | 256 |
| **Runs** | 2 warmup + 15 timed (mean) |

## Results — latency, ms (lower is better)

| Configuration | `main` | `optimization_improvements` | Speedup |
|---|---:|---:|---:|
| CPU eager | 5452.2 | 5142.5 | **1.06x** |
| CPU compiled | 4271.6 | 3425.3 | **1.25x** |
| CUDA eager | 901.3 | 782.6 | **1.15x** |
| CUDA compiled | 172.9 | 148.5 | **1.16x** |



